### PR TITLE
Added auto discovery of subnets in NSG bindings extract

### DIFF
--- a/AsmToArmMigrationApiToolset/README.md
+++ b/AsmToArmMigrationApiToolset/README.md
@@ -278,7 +278,7 @@ Send the customer the **MetadataExtract.zip** file containing the PowerShell scr
 
 ### NSG Bindings
 
-To extract NSGs and rules, first modify the script **NSG-Bindings.ps1** with the subnets from the vNet to be migrated. Follow the example in the PowerShell script. There is no API to retrieve the ASM subnets, and the subnet names are needed to query and see which NSGs are associated with each subnet. The subnet names can be obtained from the exported network config file.
+To extract NSGs and rules, execute the script **NSG-Bindings.ps1** and confirm which subnet you want to include in migration.
 
 ### AsmMetadataParser
 

--- a/AsmToArmMigrationApiToolset/Scripts/ExtractScripts/NSG-Bindings.ps1
+++ b/AsmToArmMigrationApiToolset/Scripts/ExtractScripts/NSG-Bindings.ps1
@@ -4,13 +4,13 @@ Purpose: Extract the Network Security Groups and rules for an ASM virtual networ
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$True)]
-    [ValidateNotNullOrEmpty()]
-    $subscriptionID,
+  [Parameter(Mandatory=$True)]
+  [ValidateNotNullOrEmpty()]
+  $subscriptionID,
 
-    [Parameter(Mandatory=$True)]
-    [ValidateNotNullOrEmpty()]
-    $virtualNetworkName
+  [Parameter(Mandatory=$True)]
+  [ValidateNotNullOrEmpty()]
+  $virtualNetworkName
 )
 
 Select-AzureSubscription -SubscriptionId $subscriptionID
@@ -21,15 +21,40 @@ $groups = Get-AzureNetworkSecurityGroup
 
 foreach ($group in $groups)
 {
-   (Get-AzureNetworkSecurityGroup -Name $group.Name -Detailed).Rules | Export-csv -path (".\" + $group.Name + "_" + $subscriptionID + ".csv") 
+  (Get-AzureNetworkSecurityGroup -Name $group.Name -Detailed).Rules | Export-csv -path (".\" + $group.Name + "_" + $subscriptionID + ".csv") 
 }
 
 # Now go through all subnets in the vnet, and show which NSG is associated to each subnet. Send this to a txt file.
-# Edit this section. Follow the pattern. List the subnets in the vnet to be migrated as below.
+$vnetConfig = [xml](Get-AzureVNetConfig).XMLConfiguration
+$virtualNetworkSubnets = $vnetConfig | Select-Xml "//Any:VirtualNetworkSite[@name='$virtualNetworkName']/Any:Subnets/*" -Namespace @{ Any = $vnetConfig.DocumentElement.Attributes["xmlns"].Value }
+
+if(-not $virtualNetworkSubnets) {
+  Write-Warning 'Could not find configuration for virtual network'
+  exit -1
+}
+
+$title = "$virtualNetworkName subnets migration"
+$yesOption = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Include subnet in migration."
+$noOption = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Exclude subnet from migration."
+$options = [System.Management.Automation.Host.ChoiceDescription[]]($yesOption, $noOption)
+
 
 "Subnets on vnet: " + $virtualNetworkName | Out-File (".\nsg_" + $subscriptionID + ".txt")
 "" | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
-"Subnet-1" | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
-Get-AzureNetworkSecurityGroupAssociation -VirtualNetworkName $virtualNetworkName -SubnetName "Subnet-1" | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
-"Subnet-2" | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
-Get-AzureNetworkSecurityGroupAssociation -VirtualNetworkName $virtualNetworkName -SubnetName "Subnet-2" | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
+
+$virtualNetworkSubnets.Node | % {
+  $subnetName = $_.name
+
+  $message = "Do you want to include subnet '$subnetName' in migration ?"
+  $result = $host.ui.PromptForChoice($title, $message, $options, 0) 
+
+  switch ($result)
+  {
+    0 {
+      $subnetName | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
+      Get-AzureNetworkSecurityGroupAssociation -VirtualNetworkName $virtualNetworkName -SubnetName $subnetName -ErrorAction Continue | Out-File -Append (".\nsg_" + $subscriptionID + ".txt")
+      Write-Host "'$subnetName' have been included in migration"
+    }
+    1 { Write-Host "'$subnetName' have been excluded from migration" }
+  }  
+}


### PR DESCRIPTION
This PR intend to fix issue #37 . The script NSG-Bindings.ps1 now fetch the subnet list from Azure using the `Get-AzureVNetConfig` cmdlet. It will work throuh the XML configuration to extract the list of subnets for the desired virtual network and prompt the user for each of them to have them included or not in migration like below:

```
.\NSG-Bindings.ps1 -subscriptionID 00000000-0000-0000-0000-000000000000 -virtualNetworkName VirtualNetwork1

VirtualNetwork1 subnets migration
Do you want to include subnet 'Subnet-1' in migration ?
[Y] Yes  [N] No  [?] Help (default is "Y"): y
'Subnet-1' have been included in migration

VirtualNetwork1 subnets migration
Do you want to include subnet 'GatewaySubnet' in migration ?
[Y] Yes  [N] No  [?] Help (default is "Y"): n
'GatewaySubnet' have been excluded from migration
```